### PR TITLE
Fix FTP server configuration when no port is provided

### DIFF
--- a/src/main/java/de/uni_koblenz/west/koral/common/config/impl/Configuration.java
+++ b/src/main/java/de/uni_koblenz/west/koral/common/config/impl/Configuration.java
@@ -101,7 +101,7 @@ public class Configuration implements Configurable {
   }
 
   public void setFTPServer(String ftpServerIP) {
-    setMaster(ftpServerIP, Configuration.DEFAULT_FTP_PORT);
+    setFTPServer(ftpServerIP, Configuration.DEFAULT_FTP_PORT);
   }
 
   public void setFTPServer(String ftpServerIP, String ftpServerPort) {


### PR DESCRIPTION
Fixes `Configuration::setFTPServer(String)` calling `Configuration::setMaster(String, String)` instead of `Configuration::setFTPServer(String, String)` when no FTP port is set in the config file.